### PR TITLE
#25 [FEAT] 사용자 프로필 페이지 UI

### DIFF
--- a/src/assets/icons/icon.svg
+++ b/src/assets/icons/icon.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-  <symbol id='check-circle' width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <symbol id='check-circle' width="18" height="18" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M10.5 19C15.4706 19 19.5 14.9706 19.5 10C19.5 5.02944 15.4706 1 10.5 1C5.52944 1 1.5 5.02944 1.5 10C1.5 14.9706 5.52944 19 10.5 19Z" stroke="#F87F28" stroke-width="2" stroke-linecap="round"/>
     <path d="M7.00024 11.9995L8.11924 13.3985C8.52024 13.8995 8.72124 14.1505 8.97924 14.1355C9.23724 14.1205 9.40724 13.8485 9.74824 13.3035L14.0002 6.49951" stroke="#F87F28" stroke-width="2" stroke-linecap="round"/>
   </symbol>
-  <symbol id='uncheck-circle' width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <symbol id='uncheck-circle' width="18" height="18" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M10.5 19C15.4706 19 19.5 14.9706 19.5 10C19.5 5.02944 15.4706 1 10.5 1C5.52944 1 1.5 5.02944 1.5 10C1.5 14.9706 5.52944 19 10.5 19Z" stroke="#999999" stroke-width="2" stroke-linecap="round"/>
   </symbol>
   <symbol id="check" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/assets/icons/icon.svg
+++ b/src/assets/icons/icon.svg
@@ -1,4 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id='check-circle' width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10.5 19C15.4706 19 19.5 14.9706 19.5 10C19.5 5.02944 15.4706 1 10.5 1C5.52944 1 1.5 5.02944 1.5 10C1.5 14.9706 5.52944 19 10.5 19Z" stroke="#F87F28" stroke-width="2" stroke-linecap="round"/>
+    <path d="M7.00024 11.9995L8.11924 13.3985C8.52024 13.8995 8.72124 14.1505 8.97924 14.1355C9.23724 14.1205 9.40724 13.8485 9.74824 13.3035L14.0002 6.49951" stroke="#F87F28" stroke-width="2" stroke-linecap="round"/>
+  </symbol>
+  <symbol id='uncheck-circle' width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10.5 19C15.4706 19 19.5 14.9706 19.5 10C19.5 5.02944 15.4706 1 10.5 1C5.52944 1 1.5 5.02944 1.5 10C1.5 14.9706 5.52944 19 10.5 19Z" stroke="#999999" stroke-width="2" stroke-linecap="round"/>
+  </symbol>
   <symbol id="check" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M1.25 3.75C1.25 2.36929 2.36929 1.25 3.75 1.25H16.25C17.6307 1.25 18.75 2.36929 18.75 3.75V16.25C18.75 17.6307 17.6307 18.75 16.25 18.75H3.75C2.36929 18.75 1.25 17.6307 1.25 16.25V3.75Z" fill="#FFA34E"/>
     <path d="M8.27625 14.375C8.03676 14.375 7.79728 14.2854 7.61436 14.1057L4.0241 10.5799C3.65863 10.221 3.65863 9.63875 4.0241 9.27984C4.38956 8.92094 4.98241 8.92094 5.34787 9.27984L8.27625 12.1557L14.6521 5.89418C15.0176 5.53527 15.6104 5.53527 15.9759 5.89418C16.3414 6.25308 16.3414 6.8353 15.9759 7.19421L8.93813 14.1057C8.7556 14.2854 8.51573 14.375 8.27625 14.375Z" fill="#F4F4F4"/>
@@ -36,14 +43,6 @@
   <symbol id='warning' width="230" height="43" viewBox="0 0 230 43" fill="none" xmlns="http://www.w3.org/2000/svg">
     <circle cx="114.5" cy="21.5" r="20" stroke="#FF5F5F" stroke-width="3"/>
     <path d="M113.848 24.95L113.368 12.95L113.278 9.38H116.758L116.638 12.95L116.158 24.95H113.848ZM114.988 32.39C113.698 32.39 112.708 31.4 112.708 29.99C112.708 28.55 113.698 27.53 114.988 27.53C116.308 27.53 117.328 28.55 117.328 29.99C117.328 31.4 116.308 32.39 114.988 32.39Z" fill="#FF5F5F"/>
-  </symbol>
-  <symbol id='check' width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M17.5 25C21.6421 25 25 21.6421 25 17.5C25 13.3579 21.6421 10 17.5 10C13.3579 10 10 13.3579 10 17.5C10 21.6421 13.3579 25 17.5 25Z" stroke="#F87F28" stroke-width="2" stroke-linecap="round"/>
-    <path d="M14.5835 19.1663L15.516 20.3322C15.8502 20.7497 16.0177 20.9588 16.2327 20.9463C16.4477 20.9338 16.5893 20.7072 16.8735 20.253L20.4168 14.583" stroke="#F87F28" stroke-width="2" stroke-linecap="round"/>
-  </symbol>
-  <symbol id='uncheck' width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M17.5 25C21.6421 25 25 21.6421 25 17.5C25 13.3579 21.6421 10 17.5 10C13.3579 10 10 13.3579 10 17.5C10 21.6421 13.3579 25 17.5 25Z" stroke="#909090" stroke-width="2" stroke-linecap="round"/>
-    <path d="M14.5835 19.1663L15.516 20.3322C15.8502 20.7497 16.0177 20.9588 16.2327 20.9463C16.4477 20.9338 16.5893 20.7072 16.8735 20.253L20.4168 14.583" stroke="#909090" stroke-width="2" stroke-linecap="round"/>
   </symbol>
   <symbol id='back' width="36" height="35" viewBox="0 0 36 35" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M21.5 25L14.5 17.5L21.5 10" stroke="#636363" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/assets/icons/icon.svg
+++ b/src/assets/icons/icon.svg
@@ -19,6 +19,9 @@
   <symbol id="arrow-up" width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M12 6.5L7.44121 1.31956C7.05354 0.87902 6.37162 0.865429 5.96671 1.29017L1 6.5" stroke="#999999" stroke-width="1.5" stroke-linecap="round"/>
   </symbol>
+  <symbol id='arrow-down' width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M1 1L5.55879 6.18044C5.94646 6.62098 6.62838 6.63457 7.0333 6.20983L12 1" stroke="#999999" stroke-width="1.5" stroke-linecap="round"/>
+  </symbol>
   <symbol id="message" width="current" height="current" viewBox="0 0 31 31" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M1.33101 10.7128L29.3344 1.02892C29.7316 0.891995 30.1126 1.26495 29.9691 1.64965L19.8202 28.7465C19.6511 29.1964 18.9843 29.1599 18.8689 28.6943L15.5494 15.3461C15.5065 15.1713 15.3656 15.0344 15.1858 14.9901L1.37662 11.6374C0.898966 11.5213 0.866764 10.8732 1.33101 10.7128Z" stroke="#585858" stroke-width="2" stroke-miterlimit="10"/>
     <path d="M15.0322 15.0323L30 1" stroke="#585858" stroke-width="2" stroke-miterlimit="10"/>

--- a/src/components/Button/Button.style.jsx
+++ b/src/components/Button/Button.style.jsx
@@ -24,7 +24,7 @@ export const Button = styled.button`
 
   width: ${(props) => props.$width || '100%'};
   border-radius: ${(props) => props.$borderRadius || '10px'};
-  font-weight: 600;
+  font-weight: 400;
   line-height: 29px;
   text-align: center;
   padding: ${(props) => `${props.$padding || 0} 0`};

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { Flex } from '../Common';
 import { Icon } from '../Icon';
@@ -35,7 +36,9 @@ export default function Header() {
             <span>사용자 관리</span>
           </S.MenuItem>
           <S.MenuItem>
-            <Avatar src={Img} size='37px' />
+            <Link to='/user-profile'>
+              <Avatar src={Img} size='37px' />
+            </Link>
           </S.MenuItem>
         </Flex>
       </S.HeaderContainer>

--- a/src/components/Input/Checkbox/Checkbox.jsx
+++ b/src/components/Input/Checkbox/Checkbox.jsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { Icon } from '../../Icon/index.js';
+
+import * as S from './Checkbox.style.jsx';
+
+export default function Checkbox({ children, callback }) {
+  const [checked, setChecked] = useState(false);
+  const handleCheck = (event) => {
+    setChecked(event.target.checked);
+    callback(event.target.checked);
+  };
+
+  return (
+    <S.CheckBoxLayout>
+      <Icon
+        id={checked ? 'check-circle' : 'uncheck-circle'}
+        width='18'
+        height='18'
+      />
+      <S.Input type='checkbox' value={checked} onChange={handleCheck} />
+      {children}
+    </S.CheckBoxLayout>
+  );
+}

--- a/src/components/Input/Checkbox/Checkbox.style.jsx
+++ b/src/components/Input/Checkbox/Checkbox.style.jsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const CheckBoxLayout = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+`;
+
+export const Input = styled.input`
+  display: none;
+`;

--- a/src/components/Input/Dropdown/Dropdown.jsx
+++ b/src/components/Input/Dropdown/Dropdown.jsx
@@ -17,7 +17,7 @@ export default function DropDown({ options, placeholder, callback }) {
   return (
     <S.Select onClick={() => setIsOpen((prev) => !prev)}>
       <S.Text $placeholder={!value}>{value?.name ?? placeholder}</S.Text>
-      <Icon id='arrow-up' width='13' height='8' />
+      <Icon id={isOpen ? 'arrow-up' : 'arrow-down'} width='13' height='8' />
       <S.OptionList $show={isOpen}>
         {options.map((option) => (
           <S.OptionItem

--- a/src/components/Input/Dropdown/Dropdown.jsx
+++ b/src/components/Input/Dropdown/Dropdown.jsx
@@ -4,7 +4,7 @@ import { Icon } from '../../Icon';
 
 import * as S from './Dropdown.style.jsx';
 
-export default function DropDown({ options, placeholder, callback }) {
+export default function DropDown({ width, options, placeholder, callback }) {
   const [value, setValue] = useState();
   const [isOpen, setIsOpen] = useState(false);
   const update = (event) => {
@@ -15,7 +15,7 @@ export default function DropDown({ options, placeholder, callback }) {
   };
 
   return (
-    <S.Select onClick={() => setIsOpen((prev) => !prev)}>
+    <S.Select $width={width} onClick={() => setIsOpen((prev) => !prev)}>
       <S.Text $placeholder={!value}>{value?.name ?? placeholder}</S.Text>
       <Icon id={isOpen ? 'arrow-up' : 'arrow-down'} width='13' height='8' />
       <S.OptionList $show={isOpen}>

--- a/src/components/Input/Dropdown/Dropdown.jsx
+++ b/src/components/Input/Dropdown/Dropdown.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+import { Icon } from '../../Icon';
+
+import * as S from './Dropdown.style.jsx';
+
+export default function DropDown({ options, placeholder, callback }) {
+  const [value, setValue] = useState();
+  const [isOpen, setIsOpen] = useState(false);
+  const update = (event) => {
+    event.stopPropagation();
+    setValue(JSON.parse(event.target.dataset.value));
+    callback(JSON.parse(event.target.dataset.value));
+    setIsOpen(false);
+  };
+
+  return (
+    <S.Select onClick={() => setIsOpen((prev) => !prev)}>
+      <S.Text $placeholder={!value}>{value?.name ?? placeholder}</S.Text>
+      <Icon id='arrow-up' width='13' height='8' />
+      <S.OptionList $show={isOpen}>
+        {options.map((option) => (
+          <S.OptionItem
+            key={option.value}
+            data-value={JSON.stringify(option)}
+            onClick={update}
+          >
+            {option?.name}
+          </S.OptionItem>
+        ))}
+      </S.OptionList>
+    </S.Select>
+  );
+}

--- a/src/components/Input/Dropdown/Dropdown.style.jsx
+++ b/src/components/Input/Dropdown/Dropdown.style.jsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+export const Select = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border: none;
+  border-radius: 10px;
+  background: ${(props) => props.theme.color.gray5};
+  position: relative;
+  cursor: pointer;
+
+  font-weight: 400;
+  font-size: 15px;
+  line-height: 22px;
+  color: ${(props) => props.theme.color.gray1};
+`;
+
+export const Text = styled.span`
+  color: ${(props) => (props.$placeholder ? '#999999' : 'black')};
+`;
+
+export const OptionList = styled.ul`
+  width: 100%;
+  margin-top: 10px;
+  display: ${(props) => (props.$show ? 'block' : 'none')};
+  background: ${(props) => props.theme.color.gray5};
+  border-radius: 10px;
+  position: absolute;
+  top: 100%;
+  left: 0;
+`;
+
+export const OptionItem = styled.li`
+  margin: 5px;
+  padding: 8px 10px;
+  border-radius: 10px;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: #e6e6e6;
+  }
+`;

--- a/src/components/Input/Dropdown/Dropdown.style.jsx
+++ b/src/components/Input/Dropdown/Dropdown.style.jsx
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 
 export const Select = styled.div`
+  width: ${(props) => props.$width ?? 'auto'};
+  padding: 16px 10px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 14px;
+  flex-shrink: 0;
   border: none;
   border-radius: 10px;
   background: ${(props) => props.theme.color.gray5};
@@ -12,8 +14,7 @@ export const Select = styled.div`
   cursor: pointer;
 
   font-weight: 400;
-  font-size: 15px;
-  line-height: 22px;
+  font-size: 14px;
   color: ${(props) => props.theme.color.gray1};
 `;
 
@@ -23,6 +24,7 @@ export const Text = styled.span`
 
 export const OptionList = styled.ul`
   width: 100%;
+  max-height: 170px;
   margin-top: 10px;
   display: ${(props) => (props.$show ? 'block' : 'none')};
   background: ${(props) => props.theme.color.gray5};
@@ -30,6 +32,8 @@ export const OptionList = styled.ul`
   position: absolute;
   top: 100%;
   left: 0;
+  filter: drop-shadow(2px 4px 4px rgba(0, 0, 0, 0.15));
+  overflow-y: auto;
 `;
 
 export const OptionItem = styled.li`

--- a/src/components/Input/Radio/Radio.jsx
+++ b/src/components/Input/Radio/Radio.jsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+import { Icon } from '../../Icon';
+
+import * as S from './Radio.style.jsx';
+
+export default function Radio({ name, value, currentValue, children }) {
+  return (
+    <S.RadioLayout>
+      <Icon
+        id={currentValue === value ? 'check-circle' : 'uncheck-circle'}
+        width='18'
+        height='18'
+      />
+      <S.RadioStyle type='radio' name={name} value={value} />
+      <S.Label>{children}</S.Label>
+      {/* <span>{children}</span> */}
+    </S.RadioLayout>
+  );
+}

--- a/src/components/Input/Radio/Radio.jsx
+++ b/src/components/Input/Radio/Radio.jsx
@@ -4,7 +4,13 @@ import { Icon } from '../../Icon';
 
 import * as S from './Radio.style.jsx';
 
-export default function Radio({ name, value, currentValue, children }) {
+export default function Radio({
+  name,
+  value,
+  currentValue,
+  defaultChecked = false,
+  children,
+}) {
   return (
     <S.RadioLayout>
       <Icon
@@ -12,7 +18,12 @@ export default function Radio({ name, value, currentValue, children }) {
         width='18'
         height='18'
       />
-      <S.RadioStyle type='radio' name={name} value={value} />
+      <S.RadioStyle
+        type='radio'
+        name={name}
+        value={value}
+        defaultChecked={defaultChecked}
+      />
       <S.Label>{children}</S.Label>
       {/* <span>{children}</span> */}
     </S.RadioLayout>

--- a/src/components/Input/Radio/Radio.style.jsx
+++ b/src/components/Input/Radio/Radio.style.jsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const RadioLayout = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+`;
+
+export const RadioStyle = styled.input`
+  display: none;
+`;
+
+export const Label = styled.span`
+  font-weight: 400;
+  font-size: 15px;
+  letter-spacing: -0.005em;
+`;

--- a/src/components/Input/RadioGroup/RadioGroup.jsx
+++ b/src/components/Input/RadioGroup/RadioGroup.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 
 import * as S from './RadioGroup.style.jsx';
 
-export default function RadioGroup({ name, callback, children }) {
-  const [value, setValue] = useState();
+export default function RadioGroup({ name, defaultValue, callback, children }) {
+  const [value, setValue] = useState(defaultValue);
   const handleRadio = (event) => {
     setValue(event.target.value);
     callback(event.target.value);

--- a/src/components/Input/RadioGroup/RadioGroup.jsx
+++ b/src/components/Input/RadioGroup/RadioGroup.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+import * as S from './RadioGroup.style.jsx';
+
+export default function RadioGroup({ name, callback, children }) {
+  const [value, setValue] = useState();
+  const handleRadio = (event) => {
+    setValue(event.target.value);
+    callback(event.target.value);
+  };
+
+  return (
+    <S.RadioGroupLayout onChange={handleRadio}>
+      {children.map((child, index) =>
+        React.cloneElement(child, {
+          key: index,
+          name,
+          currentValue: value,
+          callback: setValue,
+        })
+      )}
+    </S.RadioGroupLayout>
+  );
+}

--- a/src/components/Input/RadioGroup/RadioGroup.style.jsx
+++ b/src/components/Input/RadioGroup/RadioGroup.style.jsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const RadioGroupLayout = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;

--- a/src/components/Input/RadioGroup/RadioGroup.style.jsx
+++ b/src/components/Input/RadioGroup/RadioGroup.style.jsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
 export const RadioGroupLayout = styled.div`
+  width: 195px;
+  padding: 8px 0;
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
+  gap: 21px;
 `;

--- a/src/components/Input/TextInput/TextInput.jsx
+++ b/src/components/Input/TextInput/TextInput.jsx
@@ -1,0 +1,5 @@
+import * as S from './TextInput.style.jsx';
+
+export default function TextInput({ type, value, placeholder }) {
+  return <S.InputStyle type={type} value={value} placeholder={placeholder} />;
+}

--- a/src/components/Input/TextInput/TextInput.style.jsx
+++ b/src/components/Input/TextInput/TextInput.style.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const InputStyle = styled.input`
   width: 100%;
-  padding: 10px 14px;
+  padding: 16px 10px;
   color: ${(props) => props.theme.color.gray1};
   background: ${(props) => props.theme.color.gray5};
   border-radius: 10px;
@@ -10,10 +10,8 @@ export const InputStyle = styled.input`
   outline: none;
   font-weight: 400;
   font-size: 14px;
-  line-height: 22px;
-  letter-spacing: -0.005em;
 
   &::placeholder {
-    color: #999999;
+    color: #b3b3b3;
   }
 `;

--- a/src/components/Input/TextInput/TextInput.style.jsx
+++ b/src/components/Input/TextInput/TextInput.style.jsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const InputStyle = styled.input`
+  width: 100%;
+  padding: 10px 14px;
+  color: ${(props) => props.theme.color.gray1};
+  background: ${(props) => props.theme.color.gray5};
+  border-radius: 10px;
+  border: none;
+  outline: none;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: -0.005em;
+
+  &::placeholder {
+    color: #999999;
+  }
+`;

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,0 +1,1 @@
+export { default as Checkbox } from './Checkbox/Checkbox';

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,3 +1,5 @@
 export { default as Checkbox } from './Checkbox/Checkbox';
 export { default as Dropdown } from './Dropdown/Dropdown';
+export { default as Radio } from './Radio/Radio';
+export { default as RadioGroup } from './RadioGroup/RadioGroup';
 export { default as TextInput } from './TextInput/TextInput';

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,1 +1,2 @@
 export { default as Checkbox } from './Checkbox/Checkbox';
+export { default as TextInput } from './TextInput/TextInput';

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,2 +1,3 @@
 export { default as Checkbox } from './Checkbox/Checkbox';
+export { default as Dropdown } from './Dropdown/Dropdown';
 export { default as TextInput } from './TextInput/TextInput';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,2 +1,3 @@
+export { AGE_LIST, TELECOM_LIST } from './option.js';
 export { SIDE_MENUS } from './menu.js';
 export { SORT_CATEGORIES } from './sort.js';

--- a/src/constants/option.js
+++ b/src/constants/option.js
@@ -1,0 +1,17 @@
+export const TELECOM_LIST = Object.freeze([
+  { value: 'SKT', name: 'SKT' },
+  { value: 'KT', name: 'KT' },
+  { value: 'LG', name: 'LG' },
+  { value: '알뜰폰', name: '알뜰폰' },
+]);
+
+export const AGE_LIST = Object.freeze([
+  { value: 1, name: '1세' },
+  { value: 2, name: '2세' },
+  { value: 3, name: '3세' },
+  { value: 4, name: '4세' },
+  { value: 5, name: '5세' },
+  { value: 6, name: '6세' },
+  { value: 7, name: '7세' },
+  { value: 8, name: '8세' },
+]);

--- a/src/pages/AlbumMakingPage/index.js
+++ b/src/pages/AlbumMakingPage/index.js
@@ -1,0 +1,1 @@
+export { default as AlbumMakingPage } from './AlbumMakingPage';

--- a/src/pages/UserProfilePage/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage/UserProfilePage.jsx
@@ -1,0 +1,102 @@
+import { Button } from '../../components/Button';
+import {
+  Checkbox,
+  Dropdown,
+  Radio,
+  RadioGroup,
+  TextInput,
+} from '../../components/Input';
+import { Flex } from '../../components/Common';
+import { Profile } from '../../components/Profile';
+import { RandomFriend } from '../../components/RandomFriend';
+
+import { AGE_LIST, TELECOM_LIST } from '../../constants';
+
+import * as S from './UserProfilePage.style.jsx';
+
+const userId = 1;
+
+export default function UserProfilePage() {
+  return (
+    <S.UserProfileLayout>
+      <S.MainWrapper>
+        <S.MainContainer>
+          <S.Fieldset>
+            <S.Title>회원정보</S.Title>
+            <S.Field>
+              <S.Label>성별</S.Label>
+              <RadioGroup name='gender' defaultValue='male' callback={() => {}}>
+                <Radio value='male' defaultChecked>
+                  남성
+                </Radio>
+                <Radio value='female'>여성</Radio>
+              </RadioGroup>
+            </S.Field>
+            <S.Field>
+              <S.Label>생년월일</S.Label>
+              <Flex $gap='17px'>
+                <TextInput type='text' placeholder='년도' />
+                <TextInput type='text' placeholder='월' />
+                <TextInput type='text' placeholder='일' />
+              </Flex>
+            </S.Field>
+            <S.Field>
+              <S.Label>전화번호</S.Label>
+              <Flex $gap='17px'>
+                <Dropdown
+                  width='96px'
+                  options={TELECOM_LIST}
+                  placeholder='통신사'
+                  callback={(data) => {}}
+                />
+                <TextInput type='text' placeholder='전화번호를 입력해주세요' />
+              </Flex>
+            </S.Field>
+            <S.Field>
+              <S.Label>거주지</S.Label>
+              <Flex $gap='17px'>
+                <TextInput type='text' placeholder='거주지를 입력해주세요' />
+                <Button width='120px' padding='11px'>
+                  주소 검색
+                </Button>
+              </Flex>
+            </S.Field>
+          </S.Fieldset>
+          <S.Fieldset>
+            <S.Title>반려동물 정보</S.Title>
+            <S.Field>
+              <S.Label>이름</S.Label>
+              <TextInput
+                type='text'
+                placeholder='반려동물의 이름을 입력해주세요'
+              />
+            </S.Field>
+            <S.Field>
+              <S.Label>성별</S.Label>
+              <RadioGroup name='gender' defaultValue='male' callback={() => {}}>
+                <Radio value='male' defaultChecked>
+                  수컷
+                </Radio>
+                <Radio value='female'>암컷</Radio>
+              </RadioGroup>
+            </S.Field>
+            <S.Field>
+              <S.Label>나이</S.Label>
+              <Dropdown
+                width='96px'
+                options={AGE_LIST}
+                placeholder='0세'
+                callback={(data) => {}}
+              />
+            </S.Field>
+          </S.Fieldset>
+          <Button padding='20px'>저장하기</Button>
+        </S.MainContainer>
+      </S.MainWrapper>
+      <S.SideContainer>
+        <Profile userId={userId} />
+        <RandomFriend />
+      </S.SideContainer>
+    </S.UserProfileLayout>
+  );
+}

--- a/src/pages/UserProfilePage/UserProfilePage.style.jsx
+++ b/src/pages/UserProfilePage/UserProfilePage.style.jsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+import { Layout } from '../../components/Common';
+
+export const UserProfileLayout = styled.main`
+  padding: 0 30px;
+  margin-bottom: 100px;
+  display: flex;
+  gap: 30px;
+`;
+
+// main
+
+export const MainWrapper = styled(Layout)`
+  min-width: 700px;
+  flex: 1;
+  padding: 33px 0 100px 33px;
+  overflow: hidden;
+`;
+
+export const MainContainer = styled(Layout)`
+  width: 75%;
+`;
+
+export const Fieldset = styled.div`
+  margin-bottom: 38px;
+`;
+
+export const Title = styled.h2`
+  padding-bottom: 8px;
+  border-bottom: 1px solid #dfdfdf;
+  font-weight: 500;
+  font-size: 23px;
+  line-height: 33px;
+  display: flex;
+  align-items: center;
+`;
+
+export const Field = styled.div`
+  margin: 16px 0;
+`;
+
+export const Label = styled.div`
+  margin-bottom: 6px;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 140%;
+  color: #1e1e1e;
+`;
+
+// side
+export const SideContainer = styled.div`
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+`;

--- a/src/pages/UserProfilePage/index.js
+++ b/src/pages/UserProfilePage/index.js
@@ -1,0 +1,1 @@
+export { default as UserProfilePage } from './UserProfilePage';

--- a/src/route.jsx
+++ b/src/route.jsx
@@ -15,7 +15,8 @@ import { AgreePage } from './pages/AgreePage';
 import { SetNicknamePage } from './pages/SetNicknamePage';
 import { AddInfoPage } from './pages/AddInfoPage';
 import { RegisteredPage } from './pages/RegisteredPage';
-import AlbumMakingPage from './pages/AlbumMakingPage/AlbumMakingPage';
+import { UserProfilePage } from './pages/UserProfilePage';
+import { AlbumMakingPage } from './pages/AlbumMakingPage';
 
 export const routeList = [
   {
@@ -107,6 +108,10 @@ export const routeList = [
       {
         path: '/chatting',
         element: <ChattingPage />,
+      },
+      {
+        path: '/user-profile',
+        element: <UserProfilePage />,
       },
     ],
   },


### PR DESCRIPTION
## 🎯 관련 이슈

close #25

<br />

## 🚀 작업 내용

- 사용자 프로필 페이지 마크업 및 스타일링

<br />

## 📸 스크린샷

| <img width="1582" alt="image" src="https://github.com/user-attachments/assets/6f8bd900-b8be-4089-a30b-71bc425feb52"> |
| :---------------------: |

<br />


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 재사용 가능하도록 필드 요소를 컴포넌트로 분리했습니다.
  - RadioGroup, Radio
  - TextInput
  - CheckBox
  - Dropdown
- icon.svg에서 원형 모양의 체크 아이콘 id를 check-circle, uncheck-circle로 지정했습니다.