### PR TITLE
[FEAT] 개별 차단 확인 api 연결

### DIFF
--- a/src/apis/block.js
+++ b/src/apis/block.js
@@ -28,7 +28,7 @@ export const checkBlock = async ({ nickname }) => {
   const response = await authAxios.get('/blocks/status', {
     params: { nickname },
   });
-  return response;
+  return response.data.data;
 };
 
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #135

<br />

## 🚀 작업 내용

- 개별 차단 조회 api를 연결해, 다른 유저의 앨범 페이지에 접속했을 시 차단 여부를 확인하여 내가 차단한 유저의 페이지일 경우 모달을 띄워 홈 화면으로 돌아가도록 하는 기능을 구현했습니다. 
- 설정에서 차단을 해제할 경우 원래대로 페이지를 로드합니다.


<br />

## 📸 스크린샷

![스크린샷 2024-09-21 030032](https://github.com/user-attachments/assets/4bda065b-5bc1-44ec-b6d3-a958a971f314)

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
